### PR TITLE
Add skeleton for local Windows dictation app

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ GalyWhisper/
 
 ### Building from Source
 
-This prototype can be built with Go. Real functionality requires additional dependencies such as whisper.cpp and PortAudio.
+This prototype can be built with Go. Real functionality requires additional dependencies, such as whisper.cpp and PortAudio.
 
 ```bash
 # Build for Windows
@@ -99,5 +99,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [Whisper.cpp](https://github.com/ggerganov/whisper.cpp) for the Whisper model implementation
 - [PortAudio](https://www.portaudio.com/) for audio capture
-- [Wails](https://wails.io/ ) for the desktop application framework
+- [Wails](https://wails.io/) for the desktop application framework
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A privacy-first desktop dictation application for Windows that provides real-time voice-to-text transcription with 100% local execution.
 
+This repository contains a minimal Go-based prototype showing the project structure. Key components such as audio capture and Whisper integration are implemented as placeholders for further development.
+
 ## 🌟 Features
 
 - **100% Local Execution**: All processing happens on your machine - no data leaves your computer
@@ -75,6 +77,8 @@ GalyWhisper/
 
 ### Building from Source
 
+This prototype can be built with Go. Real functionality requires additional dependencies such as whisper.cpp and PortAudio.
+
 ```bash
 # Build for Windows
 go build -o GalyWhisper.exe ./cmd/galywhisper
@@ -95,4 +99,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [Whisper.cpp](https://github.com/ggerganov/whisper.cpp) for the Whisper model implementation
 - [PortAudio](https://www.portaudio.com/) for audio capture
-- [Wails](https://wails.io/) for the desktop application framework 
+- [Wails](https://wails.io/ ) for the desktop application framework
+

--- a/cmd/galywhisper/main.go
+++ b/cmd/galywhisper/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/example/galywhisper/internal/audio"
+	"github.com/example/galywhisper/internal/keyboard"
+	"github.com/example/galywhisper/internal/whisper"
+)
+
+func main() {
+	fmt.Println("GalyWhisper starting...")
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// placeholder hotkey: start immediately, stop on ctrl+c
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	fmt.Println("Recording... press Ctrl+C to stop")
+	audioData, err := audio.Record(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Transcribing...")
+	text, err := whisper.Transcribe(ctx, audioData)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Transcription: %s\n", text)
+	keyboard.Type(text)
+
+	time.Sleep(500 * time.Millisecond)
+	return nil
+}

--- a/cmd/galywhisper/main.go
+++ b/cmd/galywhisper/main.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/example/galywhisper/internal/audio"
-	"github.com/example/galywhisper/internal/keyboard"
-	"github.com/example/galywhisper/internal/whisper"
+	"github.com/Galygious/GalyWhisper/internal/audio"
+	"github.com/Galygious/GalyWhisper/internal/keyboard"
+	"github.com/Galygious/GalyWhisper/internal/whisper"
 )
 
 func main() {
@@ -42,6 +41,5 @@ func run(ctx context.Context) error {
 	fmt.Printf("Transcription: %s\n", text)
 	keyboard.Type(text)
 
-	time.Sleep(500 * time.Millisecond)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/example/galywhisper
+
+go 1.21
+
+require (
+)
+

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
-module github.com/example/galywhisper
+module github.com/Galygious/GalyWhisper
 
 go 1.21
-
-require (
-)
-

--- a/internal/audio/audio.go
+++ b/internal/audio/audio.go
@@ -1,0 +1,14 @@
+package audio
+
+import (
+	"context"
+)
+
+// Record captures audio from the default microphone until the context is done.
+// This is a placeholder implementation. A real version would use PortAudio or
+// WASAPI to capture PCM samples.
+func Record(ctx context.Context) ([]byte, error) {
+	<-ctx.Done()
+	// Return dummy audio data
+	return []byte{}, nil
+}

--- a/internal/keyboard/keyboard.go
+++ b/internal/keyboard/keyboard.go
@@ -1,0 +1,10 @@
+package keyboard
+
+import "fmt"
+
+// Type injects the given text into the active window.
+// This placeholder implementation simply prints the text.
+// On Windows, use the SendInput API to simulate keyboard events.
+func Type(text string) {
+	fmt.Printf("[keyboard] %s\n", text)
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,4 @@
+package ui
+
+// Placeholder for UI components. In a real application, this might use Wails or
+// another framework to provide a system tray icon and settings window.

--- a/internal/whisper/whisper.go
+++ b/internal/whisper/whisper.go
@@ -1,0 +1,11 @@
+package whisper
+
+import (
+	"context"
+)
+
+// Transcribe converts raw audio into text using a Whisper model.
+// Placeholder implementation that returns a fixed string.
+func Transcribe(ctx context.Context, audio []byte) (string, error) {
+	return "TODO: integrate Whisper model", nil
+}


### PR DESCRIPTION
## Summary
- create Go module and project skeleton
- stub packages for audio capture, whisper model integration, keyboard input, and UI
- basic CLI prototype in `cmd/galywhisper`
- update README with prototype details

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847868b6cd48333bac6697bb75e194a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a minimal prototype application that records audio, transcribes it (placeholder), and simulates typing the result into the active window.
- **Documentation**
  - Updated the README to clarify the prototype status, placeholder implementations, and external dependencies.
- **Chores**
  - Added initial project structure and configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->